### PR TITLE
Allow us to set PAPI Events via command line options. FIX: #15

### DIFF
--- a/C-Hayai/src/chayai.h
+++ b/C-Hayai/src/chayai.h
@@ -101,6 +101,7 @@ CHayaiArguments _arguments = chayai_main_parse_args(argv, argc); \
 (*_arguments.outputterInit)(&_outputter); \
 chayai_set_outputter(&_outputter); \
 chayai_set_warmup_iterations(_arguments.warmupIterations); \
-chayai_run_benchmarks()
+chayai_run_benchmarks(&_arguments); \
+chayai_main_cleanup_arguments(&_arguments)
 
 #endif // CHAYAI_H

--- a/C-Hayai/src/chayai_benchmark_descriptor.h
+++ b/C-Hayai/src/chayai_benchmark_descriptor.h
@@ -3,9 +3,11 @@
 
 #include <stdint.h>
 
+#include "chayai_benchmark_result.h"
+
 typedef struct CHayaiBenchmarkDescriptor
 {
-    struct CHayaiBenchmarkSingleRunResult (*runFunction)(void);
+    void (*runFunction)(struct CHayaiBenchmarkSingleRunResult *result);
     const char* fixtureName;
     const char* benchmarkName;
     unsigned int runs;

--- a/C-Hayai/src/chayai_benchmark_result.h
+++ b/C-Hayai/src/chayai_benchmark_result.h
@@ -7,8 +7,8 @@ typedef struct CHayaiBenchmarkSingleRunResult
 {
     int64_t time;
 #ifdef USE_PAPI
-    int64_t instructions;
-    int64_t cycles;
+    int papiEventSet; // has to be set before benchmark run
+    long long int *papiCounters; // has to be allocated before benchmark run
 #endif
 } CHayaiBenchmarkSingleRunResult;
 

--- a/C-Hayai/src/chayai_benchmarker.c
+++ b/C-Hayai/src/chayai_benchmarker.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <limits.h>
@@ -10,6 +11,9 @@
 
 #include "chayai_benchmarker.h"
 
+#ifdef USE_PAPI
+#include <papi.h>
+#endif
 
 static CHayaiBenchmarkDescriptor* firstBenchmarkDescriptor = NULL;
 static CHayaiBenchmarkDescriptor* lastBenchmarkDescriptor;
@@ -44,9 +48,20 @@ void chayai_set_warmup_iterations(unsigned int warmup)
     }
 }
 
-void chayai_run_benchmarks()
+void chayai_run_benchmarks(CHayaiArguments* arguments)
 {
     CHayaiBenchmarkResult result;
+
+#ifdef USE_PAPI
+    int papiValuesCount = 0;
+    if(arguments->papiEventSet != PAPI_NULL) {
+        int retval;
+        if((retval = PAPI_list_events(arguments->papiEventSet, NULL, &papiValuesCount)) != PAPI_OK) {
+            fprintf(stderr, "PAPI error %d: %s (%s:%d)\n", retval, PAPI_strerror(retval), __FILE__, __LINE__);
+            exit(2);
+        }
+    }
+#endif
 
     if (currentOutputter == NULL) return;
     
@@ -71,11 +86,27 @@ void chayai_run_benchmarks()
             currentBenchmarkDescriptor->iterations);
 
         for(unsigned int i=0; i < result.warmupRuns; i++) {
-            currentBenchmarkDescriptor->runFunction();
+            struct CHayaiBenchmarkSingleRunResult singleRun;
+#ifdef USE_PAPI
+            singleRun.papiEventSet = arguments->papiEventSet;
+            singleRun.papiCounters = papiValuesCount == 0 ? NULL : malloc(papiValuesCount*sizeof(int64_t));
+#endif
+            currentBenchmarkDescriptor->runFunction(&singleRun);
+#ifdef USE_PAPI
+            if(singleRun.papiCounters != NULL) {
+                free(singleRun.papiCounters);
+            }
+#endif
         }
 
         for(unsigned int i=0; i < result.runs; i++) {
-            struct CHayaiBenchmarkSingleRunResult singleRun = currentBenchmarkDescriptor->runFunction();
+            struct CHayaiBenchmarkSingleRunResult singleRun;
+#ifdef USE_PAPI
+            singleRun.papiEventSet = arguments->papiEventSet;
+            singleRun.papiCounters = papiValuesCount == 0 ? NULL : malloc(papiValuesCount*sizeof(int64_t));
+            memset(singleRun.papiCounters, 0, papiValuesCount*sizeof(int64_t));
+#endif
+            currentBenchmarkDescriptor->runFunction(&singleRun);
 
             result.singleRuns[i] = singleRun;
 
@@ -83,14 +114,22 @@ void chayai_run_benchmarks()
             if (result.timeRunMin > singleRun.time) result.timeRunMin = singleRun.time;
             if (result.timeRunMax < singleRun.time) result.timeRunMax = singleRun.time;
         }
-        
-        
+
         currentOutputter->endBenchmark(
             currentBenchmarkDescriptor->fixtureName,
             currentBenchmarkDescriptor->benchmarkName,
             &result);
 
+#ifdef USE_PAPI
+        for(int i = 0; i < result.runs; i++) {
+            if(result.singleRuns[i].papiCounters != NULL) {
+                free(result.singleRuns[i].papiCounters);
+                result.singleRuns[i].papiCounters = NULL;
+            }
+        }
+#endif
         free(result.singleRuns);
+        result.singleRuns = NULL;
 
         currentBenchmarkDescriptor = currentBenchmarkDescriptor->next;
     }

--- a/C-Hayai/src/chayai_benchmarker.h
+++ b/C-Hayai/src/chayai_benchmarker.h
@@ -4,6 +4,7 @@
 #include "chayai_benchmark_descriptor.h"
 #include "chayai_benchmark_pp.h"
 #include "chayai_outputter.h"
+#include "chayai_main.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,7 +20,7 @@ void chayai_set_outputter(CHayaiOutputter* outputter);
 void chayai_set_warmup_iterations(unsigned int warmup);
 
 /// Run all registered benchmark
-void chayai_run_benchmarks();
+void chayai_run_benchmarks(CHayaiArguments* arguments);
 
 #ifdef __cplusplus
 }

--- a/C-Hayai/src/chayai_main.h
+++ b/C-Hayai/src/chayai_main.h
@@ -3,11 +3,16 @@
 
 #include "chayai_outputter.h"
 
+#define MAX_NUM_PAPI_EVENTS 32  // way to much, and therefore should always be big enough for now
+
 typedef struct CHayaiArguments {
     void (*outputterInit)(CHayaiOutputter* outputter);
     unsigned int warmupIterations;
+    int papiEventSet; // this variable always exists so benchmarks using it do not depend on the USE_PAPI definition to be present
 } CHayaiArguments;
 
 CHayaiArguments chayai_main_parse_args(int argv, char** argc);
+
+void chayai_main_cleanup_arguments(CHayaiArguments *arguments);
 
 #endif // CHAYAI_MAIN_H

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -20,6 +20,7 @@ ifdef NO_PAPI
     USE_PAPI_VALUE = OFF
 else
 	C_HAYAI_LDFLAGS += -lpapi
+	C_HAYAI_CFLAGS += -DUSE_PAPI
 	USE_PAPI_VALUE = ON
 endif
 

--- a/tools/bench.py
+++ b/tools/bench.py
@@ -296,8 +296,8 @@ def add_default_runtimes(harness):
             warmup_iterations = kwargs.get('warmup_iterations', None)
             if warmup_iterations:
                 additional_args.append('--warmup=%d' % warmup_iterations)
-            with subprocess.Popen(os.path.expandvars(tool).split(' ') + [bc_filepath, '--output=json'] + additional_args,
-                                  cwd=workdir, stdout=subprocess.PIPE) as p:
+            args = os.path.expandvars(tool).split(' ') + [bc_filepath, '--output=json'] + additional_args
+            with subprocess.Popen(args, cwd=workdir, stdout=subprocess.PIPE) as p:
                 stdout, _ = p.communicate(timeout=kwargs.get('timeout', 240))
 
                 if p.returncode != 0:


### PR DESCRIPTION
* Only enable PAPI when there are events added to the list
* Output error messages when something does not work (like events cannot be combined)

Using PAPI results in a little memory-leak, which should be not a problem on our side: https://bitbucket.org/icl/papi/issues/49/minimum-example-already-has-memory-leaks