### PR TITLE
Improve timer handling, fix bug

### DIFF
--- a/C-Hayai/src/chayai_clock.c
+++ b/C-Hayai/src/chayai_clock.c
@@ -12,7 +12,7 @@ int64_t chayai_clock_resolution_measured() {
         p1 = chayai_clock_now();
         do {
             p2 = chayai_clock_now();
-        } while((cur_time = chayai_clock_duration(p1, p2)) == 0L);
+        } while((cur_time = chayai_clock_duration(p1, p2)) <= 0L);
 
         if(cur_time < min_time) {
             min_time = cur_time;

--- a/C-Hayai/src/chayai_clock.h
+++ b/C-Hayai/src/chayai_clock.h
@@ -33,6 +33,10 @@
 #ifndef CHAYAI_CLOCK_H
 #define CHAYAI_CLOCK_H
 
+// POSIX
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <unistd.h>
+#endif
 
 // Win32
 #if defined(_WIN32)
@@ -51,8 +55,6 @@ typedef uint64_t CHayaiTimePoint;
 
 // Unix
 #elif defined(__unix__) || defined(__unix) || defined(unix)
-
-#include <unistd.h>  // required so we can check for _POSIX_TIMERS
 
 // gethrtime
 #   if (defined(__hpux) || defined(hpux)) || ((defined(__sun__) || defined(__sun) || defined(sun)) && (defined(__SVR4) || defined(__svr4__)))

--- a/C-Hayai/src/chayai_clock.h
+++ b/C-Hayai/src/chayai_clock.h
@@ -50,6 +50,8 @@ typedef uint64_t CHayaiTimePoint;
 // Unix
 #elif defined(__unix__) || defined(__unix) || defined(unix)
 
+#include <unistd.h>  // required so we can check for _POSIX_TIMERS
+
 // gethrtime
 #   if (defined(__hpux) || defined(hpux)) || ((defined(__sun__) || defined(__sun) || defined(sun)) && (defined(__SVR4) || defined(__svr4__)))
 #   include <sys/time.h>

--- a/C-Hayai/src/chayai_clock.h
+++ b/C-Hayai/src/chayai_clock.h
@@ -41,11 +41,13 @@
 #endif
 #include <windows.h>
 typedef LARGE_INTEGER CHayaiTimePoint;
+#define CHAYAI_CLOCK_TYPE "QueryPerformanceCounter"
 
 // Apple
 #elif defined(__APPLE__) && defined(__MACH__)
 #include <mach/mach_time.h>
 typedef uint64_t CHayaiTimePoint;
+#define CHAYAI_CLOCK_TYPE "mach_absolute_time"
 
 // Unix
 #elif defined(__unix__) || defined(__unix) || defined(unix)
@@ -56,16 +58,28 @@ typedef uint64_t CHayaiTimePoint;
 #   if (defined(__hpux) || defined(hpux)) || ((defined(__sun__) || defined(__sun) || defined(sun)) && (defined(__SVR4) || defined(__svr4__)))
 #   include <sys/time.h>
 typedef hrtime_t CHayaiTimePoint;
+#define CHAYAI_CLOCK_TYPE "gethrtime"
 
 // clock_gettime
 #   elif defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0)
 #   include <time.h>
 typedef struct timespec CHayaiTimePoint;
 
+#if defined(CLOCK_MONOTONIC_RAW)
+    #define CHAYAI_CLOCK_TYPE "clock_gettime(CLOCK_MONOTONIC_RAW)"
+#elif defined(CLOCK_MONOTONIC)
+    #define CHAYAI_CLOCK_TYPE "clock_gettime(CLOCK_MONOTONIC)"
+#elif defined(CLOCK_REALTIME)
+    #define CHAYAI_CLOCK_TYPE "clock_gettime(CLOCK_REALTIME)"
+#else
+    #define CHAYAI_CLOCK_TYPE "clock_gettime((clockid_t)-1)"
+#endif
+
 // gettimeofday
 #   else
 #   include <sys/time.h>
 typedef struct timeval CHayaiTimePoint;
+#define CHAYAI_CLOCK_TYPE "gettimeofday"
 
 #   endif
 #else
@@ -90,6 +104,14 @@ CHayaiTimePoint chayai_clock_now();
 /// @returns the number of nanoseconds elapsed between the two time
 /// points.
 int64_t chayai_clock_duration(CHayaiTimePoint startTime, CHayaiTimePoint endTime);
+
+/// Get the clock resolution of our clock
+/// @returns the clock resolution in nanoseconds
+int64_t chayai_clock_resolution();
+
+// Measure the clock resolution of our clock
+/// @returns the clock resolution in nanoseconds
+int64_t chayai_clock_resolution_measured();
 
 #ifdef __cplusplus
 }

--- a/C-Hayai/src/chayai_console_outputter.c
+++ b/C-Hayai/src/chayai_console_outputter.c
@@ -5,6 +5,7 @@
 
 #include "chayai_console.h"
 #include "chayai_console_outputter.h"
+#include "chayai_clock.h"
 
 #define OUTPUT_STREAM stdout
 #define PADDING 34
@@ -60,6 +61,13 @@ void chayai_console_outputter_init(CHayaiOutputter* outputter)
 
 static void chayai_console_outputter_begin(unsigned int bechmarksCount)
 {
+    const double clockResolutionUs = chayai_clock_resolution() / 1e3;
+    const double clockResolutionMeasuredUs = chayai_clock_resolution_measured() / 1e3;
+
+    chayai_console_change_color(OUTPUT_STREAM, CHAYAI_TEXT_PURPLE);
+    fprintf(OUTPUT_STREAM, "CLOCK SOURCE \"%s\" with resolution of (%f us / %f us)\n", CHAYAI_CLOCK_TYPE, clockResolutionUs, clockResolutionMeasuredUs);
+    chayai_console_change_color(OUTPUT_STREAM, CHAYAI_TEXT_DEFAULT);
+
     chayai_console_change_color(OUTPUT_STREAM, CHAYAI_TEXT_GREEN);
     fputs("[==========]", OUTPUT_STREAM);
     chayai_console_change_color(OUTPUT_STREAM, CHAYAI_TEXT_DEFAULT);

--- a/C-Hayai/src/chayai_json_outputter.c
+++ b/C-Hayai/src/chayai_json_outputter.c
@@ -4,6 +4,7 @@
 #include <math.h>
 
 #include "chayai_json_outputter.h"
+#include "chayai_clock.h"
 
 #ifdef USE_PAPI
 #include <papi.h>
@@ -123,7 +124,15 @@ static void chayai_json_outputter_end_benchmark(
     const double standardDerivationUs = sqrt(varianceUs);
 
     fprintf(OUTPUT_STREAM, "\"mean\":%f,", runTimeAvgUs);
-    fprintf(OUTPUT_STREAM, "\"std_dev\":%f", standardDerivationUs);
+    fprintf(OUTPUT_STREAM, "\"std_dev\":%f,", standardDerivationUs);
+
+    fprintf(OUTPUT_STREAM, "\"clock_type\":\"%s\",", CHAYAI_CLOCK_TYPE);
+
+    const double clockResolutionUs = chayai_clock_resolution() / 1e3;
+    fprintf(OUTPUT_STREAM, "\"clock_resolution\":%f,", clockResolutionUs);
+
+    const double clockResolutionMeasuredUs = chayai_clock_resolution_measured() / 1e3;
+    fprintf(OUTPUT_STREAM, "\"clock_resolution_measured\":%f", clockResolutionMeasuredUs);
 
     // end benchmark dict
     fputs("}", OUTPUT_STREAM);


### PR DESCRIPTION
* We actually used ```gettimeofday``` until now by default, because selection was broken
* Output some basic informations about the timer including maximum real resolution